### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 # Installation
 
-1.  `gem install webloc`
-2.  Clone the repository
-3.  Make a symlink called `webloc` in your `PATH` which points at `webloc.rb`
+1.  `gem install docopt`
+2.  `gem install webloc`
+3.  Clone the repository
+4.  Make a symlink called `webloc` in your `PATH` which points at `webloc.rb`
 
 # Usage
 


### PR DESCRIPTION
Without installing `docopt`, cli will result in `/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in`require': cannot load such file -- docopt (LoadError)`
